### PR TITLE
PULL_REQUEST_TEMPLATE.md: add link for creating new issues

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,7 @@
 <!-- 
 !IMPORTANT!
-Please do not create a Pull Request without creating an issue first.
+Please do not create a Pull Request without creating an issue first
+at https://github.com/harvester/harvester/issues/new/choose
 -->
 
 #### Problem:


### PR DESCRIPTION
This should help to make it clearer that we want all Harvester issues opened against the main Harvester repository, regardless of which repo you're actually submitting code to.

Of course, I'm breaking the rules here by not opening an issue for _this_ PR ;-)